### PR TITLE
fix wrong error notice; add documentation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,26 +47,31 @@ module.exports = function (options) {
   options.identifyUser = options.identifyUser || function () {
       return undefined;
     };
-
+  // function to add custom metadata (must be an object that can be converted to JSON)
   options.getMetadata = options.getMetadata || function () {
       return undefined;
     };
 
+  // function to add custom session token (must be a string)
   options.getSessionToken = options.getSessionToken || function () {
       return undefined;
     };
+  // function to allow adding of custom tags (this is decprecated - getMetadata should be used instead)
   options.getTags = options.getTags || function () {
       return undefined;
     };
+  // function to declare the api versionused for the request
   options.getApiVersion = options.getApiVersion || function () {
       return undefined;
     };
+  // function that allows removal of certain, unwanted fields, before it will be sent to moesif
   options.maskContent = options.maskContent || function (eventData) {
       return eventData;
     };
   options.ignoreRoute = options.ignoreRoute || function () {
       return false;
     };
+  // function where conditions can be declared, when a request should be skipped and not be tracked by moesif
   options.skip = options.skip || exports.defaultSkip;
 
   var moesifMiddleware = function (req, res, next) {
@@ -351,7 +356,7 @@ function ensureValidOptions(options) {
     throw new Error('getTags should be a function');
   }
   if (options.getApiVersion && !_.isFunction(options.getApiVersion)) {
-    throw new Error('identifyUser should be a function');
+    throw new Error('getApiVersion should be a function');
   }
   if (options.maskContent && !_.isFunction(options.maskContent)) {
     throw new Error('maskContent should be a function');


### PR DESCRIPTION
Hey there, 

due to a wrong implementation in my code within the getApiVersion function I found a wrong error message.
I have implemented the getApiVersion handler as a string, instead of a function. 
The library told me that "identifyUser" is not a function. I searched for minutes and tried to find the bug on my code - because I searched on my identifyUser function. 

But then I saw, that the error handling for getApiVersion is wrong. It took me some minutes ;)
I decided to fix that in your code. 
And furthermore I have looked around on the documentation and found some missing documentation, that I have enhanced.