### PR TITLE
improve hashSensitive detection for password

### DIFF
--- a/lib/dataUtils.js
+++ b/lib/dataUtils.js
@@ -31,7 +31,7 @@ function _hashSensitive(jsonBody, debug) {
       var innerVal = jsonBody[key];
       var innerValType = typeof innerVal;
 
-      if (key.toLowerCase() === 'password' && typeof innerVal === 'string') {
+      if (key.toLowerCase().indexOf('password') !== -1 && typeof innerVal === 'string') {
         logMessage(debug, 'hashSensitive', 'key is password, so hashing the value.');
         returnObject[key] = hash(jsonBody[key]).toString();
       } else if (innerValType === 'number' || innerValType === 'string') {


### PR DESCRIPTION
Hello,

I have improved the hashSensitive function, which prevents push of sensitive fields such as credit cards or password. The current detection only checks for key, that equals password. But if the key is "password2" or something like that, or "newpassword", it will not be stripped out / hashed.

The new handling now checks, if it's included within the key.

I think, this makes more sense :) 