### PR TITLE
check to see if _mo_send is already saved. 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -227,7 +227,9 @@ module.exports = function(options) {
     };
 
     // Manage to get information from the response too, just like Connect.logger does:
-    res._mo_end = res.end;
+    if (!res._mo_end) {
+      res._mo_end = res.end;
+    }
 
     // Add TransactionId to the response send to the client
     let disableTransactionId = options.disableTransactionId ? options.disableTransactionId : false;
@@ -249,8 +251,8 @@ module.exports = function(options) {
         finalBuf = Buffer.from(appendChunk(resBodyBuf, chunk));
       }
 
-      res.end = res._mo_end;
-      res.end(chunk, encoding, callback);
+      // res.end = res._mo_end;
+      res._mo_end(chunk, encoding, callback);
 
       try {
         // if req body already exists (set by another middleware) we can skip get rawBody.

--- a/lib/index.js
+++ b/lib/index.js
@@ -228,7 +228,10 @@ module.exports = function(options) {
 
     // Manage to get information from the response too, just like Connect.logger does:
     if (!res._mo_end) {
+      logMessage(options.debug, 'moesifMiddleware', '_mo_end is not defined so saving original end.');
       res._mo_end = res.end;
+    } else {
+      logMessage(options.debug, 'moesifMiddleware', '_mo_end is already defined. Did you attach moesif express twice?');
     }
 
     // Add TransactionId to the response send to the client

--- a/lib/index.js
+++ b/lib/index.js
@@ -254,7 +254,6 @@ module.exports = function(options) {
         finalBuf = Buffer.from(appendChunk(resBodyBuf, chunk));
       }
 
-      // res.end = res._mo_end;
       res._mo_end(chunk, encoding, callback);
 
       try {


### PR DESCRIPTION
If Moesif-express is attached twice for by mistake, do not patch the send twice. 