### PR TITLE
Rename package from moesif-express to moesif-nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Moesif Node.js Middleware
 
-[![NPM](https://nodei.co/npm/moesif-express.png?compact=true&stars=true)](https://nodei.co/npm/moesif-express/)
+[![NPM](https://nodei.co/npm/moesif-nodejs.png?compact=true&stars=true)](https://nodei.co/npm/moesif-nodejs/)
 
 [![Built For][ico-built-for]][link-built-for]
 [![Total Downloads][ico-downloads]][link-downloads]
@@ -8,19 +8,19 @@
 [![Source Code][ico-source]][link-source]
 
 Node.js SDK middleware that automatically logs _incoming_ or _outgoing_
-API calls and sends to [Moesif](https://www.moesif.com) for API analytics and log analysis.
+API calls and sends to [Moesif](https://www.moesif.com) for API analytics and monitoring.
 
-[Source Code on GitHub](https://github.com/moesif/moesif-express)
+[Source Code on GitHub](https://github.com/moesif/moesif-nodejs)
 
 ## Notes
-- The SDK is called `moesif-express` for historical reasons but compatible with any Node.js app regardless if Express Framework is used.
+- Previously, this NPM package was called `moesif-express` and has been renamed to `moesif-nodejs` in 3.0 to reflect support for any Node.js app.
 - The library can capture both _incoming_ and _outgoing_ API Calls depending on how you configure the SDK (See examples).
 - To ensure req body is captured, if you use a body parser middleware like `body-parser`, apply Moesif middleware _after_ it.
 
 ## How to install
 
 ```shell
-npm install --save moesif-express
+npm install --save moesif-nodejs
 ```
 
 ## How to use
@@ -35,7 +35,7 @@ The following shows how import the controllers and use:
 // 1. Import Modules
 var express = require('express');
 var app = express();
-var moesifExpress = require('moesif-express');
+var moesif = require('moesif-nodejs');
 
 // 2. Set the options, the only required field is applicationId.
 var options = {
@@ -57,7 +57,7 @@ var options = {
 };
 
 // 3. Initialize the middleware object with options
-var moesifMiddleware = moesifExpress(options);
+var moesifMiddleware = moesif(options);
 
 
 // 4a. Start capturing outgoing API Calls to 3rd parties like Stripe
@@ -84,7 +84,7 @@ If you're not using the express framework, you can still use this library.
 The library does not depend on express, so you can still call the middleware from a basic HTTP server.
 
 ```javascript
-var moesifExpress = require('moesif-express');
+var moesif = require('moesif-nodejs');
 const http = require('http');
 
 var options = {
@@ -93,7 +93,7 @@ var options = {
 };
 
 var server = http.createServer(function (req, res) {
-  moesifExpress(options)(req, res, function () {
+  moesif(options)(req, res, function () {
     // Callback
   });
 
@@ -344,7 +344,7 @@ If you want to capture all outgoing API calls from your Node.js app to third par
 Stripe or to your own dependencies, call `startCaptureOutgoing()` to start capturing.
 
 ```javascript
-var moesifMiddleware = moesifExpress(options);
+var moesifMiddleware = moesif(options);
 moesifMiddleware.startCaptureOutgoing();
 ```
 
@@ -375,7 +375,7 @@ This method is a convenient helper that calls the Moesif API lib.
 For details, visit the [Node.js API Reference](https://www.moesif.com/docs/api?javascript--nodejs#update-a-user).
 
 ```javascript
-var moesifMiddleware = moesifExpress(options);
+var moesifMiddleware = moesif(options);
 
 // Only userId is required.
 // Campaign object is optional, but useful if you want to track ROI of acquisition channels
@@ -414,7 +414,7 @@ This method is a convenient helper that calls the Moesif API lib.
 For details, visit the [Node.js API Reference](https://www.moesif.com/docs/api?javascript--nodejs#update-users-in-batch).
 
 ```javascript
-var moesifMiddleware = moesifExpress(options);
+var moesifMiddleware = moesif(options);
 
 // Only userId is required.
 // Campaign object is optional, but useful if you want to track ROI of acquisition channels
@@ -458,7 +458,7 @@ For details, visit the [Node.js API Reference](https://www.moesif.com/docs/api?j
 
 
 ```javascript
-var moesifMiddleware = moesifExpress(options);
+var moesifMiddleware = moesif(options);
 
 // Only companyId is required.
 // Campaign object is optional, but useful if you want to track ROI of acquisition channels
@@ -496,7 +496,7 @@ This method is a convenient helper that calls the Moesif API lib.
 For details, visit the [Node.js API Reference](https://www.moesif.com/docs/api?javascript--nodejs#update-companies-in-batch).
 
 ```javascript
-var moesifMiddleware = moesifExpress(options);
+var moesifMiddleware = moesif(options);
 
 // Only companyId is required.
 // Campaign object is optional, but useful if you want to track ROI of acquisition channels
@@ -531,7 +531,7 @@ moesifMiddleware.updateCompaniesBatch(companies, callback);
 
 ## Examples
 
-- [A complete example is available on GitHub](https://github.com/Moesif/moesif-express-example).
+- [A complete example is available on GitHub](https://github.com/Moesif/moesif-nodejs-example).
 
 - [An example of integration with Apollo.js with support for GraphQL.](https://github.com/Moesif/moesif-apollo-graphql-example)
 
@@ -541,11 +541,11 @@ To view more documentation on integration options, please visit __[the Integrati
 
 
 [ico-built-for]: https://img.shields.io/badge/built%20for-node.js-blue.svg
-[ico-downloads]: https://img.shields.io/npm/dt/moesif-express.svg
+[ico-downloads]: https://img.shields.io/npm/dt/moesif-nodejs.svg
 [ico-license]: https://img.shields.io/badge/License-Apache%202.0-green.svg
-[ico-source]: https://img.shields.io/github/last-commit/moesif/moesif-express.svg?style=social
+[ico-source]: https://img.shields.io/github/last-commit/moesif/moesif-nodejs.svg?style=social
 
 [link-built-for]: https://expressjs.com/
-[link-downloads]: https://www.npmjs.com/package/moesif-express
-[link-license]: https://raw.githubusercontent.com/Moesif/moesif-express/master/LICENSE
-[link-source]: https://github.com/moesif/moesif-express
+[link-downloads]: https://www.npmjs.com/package/moesif-nodejs
+[link-license]: https://raw.githubusercontent.com/Moesif/moesif-nodejs/master/LICENSE
+[link-source]: https://github.com/moesif/moesif-nodejs

--- a/app.js
+++ b/app.js
@@ -6,11 +6,11 @@
 var express = require('express');
 var app = express();
 
-var moesifExpress = require('./lib');
+var moesif = require('./lib');
 
 var TEST_API_SECRET_KEY = 'eyJhcHAiOiI5NDo5MiIsInZlciI6IjIuMCIsIm9yZyI6IjExNjoxMDQiLCJpYXQiOjE1NTIwMDMyMDB9.mtudzMSLcpfq0iTle-qTJLMJqBYirHqwrKG-Rz9oOaM';
 
-var moesifMiddleWare = moesifExpress({applicationId: TEST_API_SECRET_KEY});
+var moesifMiddleWare = moesif({applicationId: TEST_API_SECRET_KEY});
 
 app.use(moesifMiddleWare);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ exports.defaultSkip = function(req, res) {
 };
 
 //
-// ### function moesifExpress(options)
+// ### function moesif(options)
 // #### @options {Object} options to initialize the middleware.
 //
 
@@ -540,7 +540,7 @@ function decodeHeaders(header) {
 }
 
 function ensureValidOptions(options) {
-  if (!options) throw new Error('options are required by moesif-express middleware');
+  if (!options) throw new Error('options are required by moesif-nodejs middleware');
   if (!options.applicationId)
     throw new Error(
       'A moesif application id is required. Please obtain it through your settings at www.moesif.com'

--- a/lib/moesifConfigManager.js
+++ b/lib/moesifConfigManager.js
@@ -47,7 +47,7 @@ MoesifConfigManager.prototype.tryGetConfig = function () {
           that._config = JSON.parse(event.response.body);
           that._lastConfigUpdate = now();
         } catch (e) {
-          console.warn('moesif-express: error parsing config');
+          console.warn('moesif-nodejs: error parsing config');
         }
       }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "moesif-express",
-  "version": "2.9.19",
+  "name": "moesif-nodejs",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "moesif-express",
-  "version": "2.9.19",
-  "description": "Collection/Data Ingestion Middleware for Node.js",
+  "name": "moesif-nodejs",
+  "version": "3.0.0",
+  "description": "Monitoring agent to log API calls to Moesif for deep API analytics",
   "main": "lib/index.js",
   "keywords": [
     "moesif",
@@ -19,7 +19,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Moesif/moesif-express"
+    "url": "https://github.com/Moesif/moesif-nodejs"
   },
   "dependencies": {
     "bytes": "^3.1.0",

--- a/test/mockserver.js
+++ b/test/mockserver.js
@@ -10,7 +10,7 @@ var Promise = require('promise/lib/es6-extensions');
 var should = require('should');
 var expect = require('chai').expect;
 var _ = require('lodash');
-var moesifExpress = require('../lib');
+var moesif = require('../lib');
 
 // replace with an moesif application id token to test..
 var TEST_API_SECRET_KEY = 'Your Moesif Application Id';
@@ -79,7 +79,7 @@ function loggerTestHelper(providedOptions, moesifOptions) {
       moesifOptions
     );
 
-    var middleware = moesifExpress(moesifMiddleWareOptions);
+    var middleware = moesif(moesifMiddleWareOptions);
 
     middleware(req, res, function(_req, _res, next) {
       options.next(req, res, next);
@@ -89,17 +89,17 @@ function loggerTestHelper(providedOptions, moesifOptions) {
 }
 
 if (RUN_TEST) {
-  describe('moesif-express', function() {
+  describe('moesif-nodejs', function() {
     describe('fail cases', function() {
       it('throw an error when not provided an application id.', function() {
         expect(function() {
-          moesifExpress({});
+          moesif({});
         }).to.throw(Error);
       });
 
       it('throw an error when identifyUser is not a function', function() {
         expect(function() {
-          moesifExpress({
+          moesif({
             applicationId: TEST_API_SECRET_KEY,
             identifyUser: 'abc'
           });
@@ -111,7 +111,7 @@ if (RUN_TEST) {
       this.timeout(3000);
 
       it('middleware should be function that takes 3 arguments', function() {
-        expect(moesifExpress({ applicationId: TEST_API_SECRET_KEY }).length).to.equal(3);
+        expect(moesif({ applicationId: TEST_API_SECRET_KEY }).length).to.equal(3);
       });
 
       it('test one successful submission without body', function(done) {
@@ -300,7 +300,7 @@ if (RUN_TEST) {
       });
 
       it('should be able to update user profile to Moesif.', function(done) {
-        var moesifMiddleware = moesifExpress({ applicationId: TEST_API_SECRET_KEY });
+        var moesifMiddleware = moesif({ applicationId: TEST_API_SECRET_KEY });
 
         moesifMiddleware.updateUser(
           {
@@ -318,7 +318,7 @@ if (RUN_TEST) {
       });
 
       it('should be able to update user profiles in batch to Moesif.', function(done) {
-        var moesifMiddleware = moesifExpress({ applicationId: TEST_API_SECRET_KEY });
+        var moesifMiddleware = moesif({ applicationId: TEST_API_SECRET_KEY });
 
         var users = []
 
@@ -344,7 +344,7 @@ if (RUN_TEST) {
       });
 
       it('should be able to update company profiles to Moesif.', function(done) {
-        var moesifMiddleware = moesifExpress({ applicationId: TEST_API_SECRET_KEY });
+        var moesifMiddleware = moesif({ applicationId: TEST_API_SECRET_KEY });
 
         moesifMiddleware.updateCompany({
           companyId: '12345',
@@ -361,7 +361,7 @@ if (RUN_TEST) {
       });
 
       it('should be able to update company profiles in batch to Moesif.', function(done) {
-        var moesifMiddleware = moesifExpress({ applicationId: TEST_API_SECRET_KEY });
+        var moesifMiddleware = moesif({ applicationId: TEST_API_SECRET_KEY });
 
         var companies = []
 

--- a/test/outgoingWithMoesifExpress.js
+++ b/test/outgoingWithMoesifExpress.js
@@ -2,7 +2,7 @@
 var http = require('http');
 var https = require('https');
 var patch = require('../lib/outgoing');
-var moesifExpress = require('../lib');
+var moesif = require('../lib');
 var _ = require('lodash');
 
 var RUN_TEST = true;
@@ -60,7 +60,7 @@ if (RUN_TEST) {
           return false;
         };
 
-      var middleware = moesifExpress(options);
+      var middleware = moesif(options);
       middleware.startCaptureOutgoing();
     });
 


### PR DESCRIPTION
This library supports any Node.js app including Express, Next.js, etc. Rename package for clarity and deprecate old name on NPM.