### PR TITLE
try to decompress binary when header content-encoding missing

### DIFF
--- a/lib/dataUtils.js
+++ b/lib/dataUtils.js
@@ -20,20 +20,35 @@ function decompressIfNeeded(body, headers) {
   var buf = Buffer.isBuffer(body) ? body : Buffer.from(body);
   var encoding = (headers && (headers['content-encoding'] || headers['Content-Encoding'])) || '';
   var server = (headers && (headers['server'] || headers['Server'])) || '';
+  var contentType = (headers && (headers['content-type'] || headers['Content-Type'])) || '';
   var decompressed = null;
   var isBinary = isBinaryBuffer(buf);
+
+  // Only decompress if content-type is json, xml, or text
+  var isTextType = false;
+  if (contentType) {
+    var ct = contentType.toLowerCase();
+    if (ct.indexOf('json') !== -1 || ct.indexOf('xml') !== -1 || ct.indexOf('text') !== -1) {
+      isTextType = true;
+    }
+  }
+  if (!isTextType) {
+    // Not a text type, skip decompression
+    return body;
+  }
+
   try {
     if (encoding && isBinary) {
-      if (encoding.includes('gzip')) {
+      if (encoding.indexOf('gzip') !== -1) {
         decompressed = zlib.gunzipSync(buf);
-      } else if (encoding.includes('deflate')) {
+      } else if (encoding.indexOf('deflate') !== -1) {
         decompressed = zlib.inflateSync(buf);
-      } else if (encoding.includes('br')) {
+      } else if (encoding.indexOf('br') !== -1) {
         decompressed = zlib.brotliDecompressSync(buf);
       }
     } else if (isBinary) {
       // Heuristic: try brotli if server is cloudflare
-      if (server.toLowerCase().includes('cloudflare')) {
+      if (server.toLowerCase().indexOf('cloudflare') !== -1) {
         try {
           decompressed = zlib.brotliDecompressSync(buf);
         } catch (e) {
@@ -52,9 +67,8 @@ function decompressIfNeeded(body, headers) {
           decompressed = zlib.inflateSync(buf);
         } catch (e) {}
       }
-
       // As last resort, try brotli if not already tried
-      if (!decompressed && !server.toLowerCase().includes('cloudflare')) {
+      if (!decompressed && server.toLowerCase().indexOf('cloudflare') === -1) {
         try {
           decompressed = zlib.brotliDecompressSync(buf);
         } catch (e) {

--- a/lib/dataUtils.js
+++ b/lib/dataUtils.js
@@ -19,7 +19,7 @@ function decompressIfNeeded(body, headers) {
   if (!body) return body;
   var buf = Buffer.isBuffer(body) ? body : Buffer.from(body);
   var encoding = (headers && (headers['content-encoding'] || headers['Content-Encoding'])) || '';
-  var server = headers && (headers['server'] || headers['Server']) || '';
+  var server = (headers && (headers['server'] || headers['Server'])) || '';
   var decompressed = null;
   var isBinary = isBinaryBuffer(buf);
   try {
@@ -52,6 +52,15 @@ function decompressIfNeeded(body, headers) {
           decompressed = zlib.inflateSync(buf);
         } catch (e) {}
       }
+
+      // As last resort, try brotli if not already tried
+      if (!decompressed && !server.toLowerCase().includes('cloudflare')) {
+        try {
+          decompressed = zlib.brotliDecompressSync(buf);
+        } catch (e) {
+          // fallback below
+        }
+      }
     }
     if (decompressed) {
       // Try to return as string if possible
@@ -77,8 +86,7 @@ var logMessage = function (debug, functionName, message, details) {
           finalMessage = message + '\n' + JSON.stringify(details);
         }
       }
-    } catch (err) {
-    }
+    } catch (err) {}
     console.log('MOESIF: [' + functionName + '] ' + finalMessage);
   }
 };
@@ -97,11 +105,7 @@ function _hashSensitive(jsonBody, debug) {
       if (itemType === 'number' || itemType === 'string') {
         var creditCardCheck = isCreditCard.number('' + item);
         if (creditCardCheck.isValid) {
-          logMessage(
-            debug,
-            'hashSensitive',
-            'looks like a credit card, performing hash.'
-          );
+          logMessage(debug, 'hashSensitive', 'looks like a credit card, performing hash.');
           return hash(item).toString();
         }
       }
@@ -117,24 +121,13 @@ function _hashSensitive(jsonBody, debug) {
       var innerVal = jsonBody[key];
       var innerValType = typeof innerVal;
 
-      if (
-        key.toLowerCase().indexOf('password') !== -1 &&
-        typeof innerVal === 'string'
-      ) {
-        logMessage(
-          debug,
-          'hashSensitive',
-          'key is password, so hashing the value.'
-        );
+      if (key.toLowerCase().indexOf('password') !== -1 && typeof innerVal === 'string') {
+        logMessage(debug, 'hashSensitive', 'key is password, so hashing the value.');
         returnObject[key] = hash(jsonBody[key]).toString();
       } else if (innerValType === 'number' || innerValType === 'string') {
         var creditCardCheck = isCreditCard.number('' + innerVal);
         if (creditCardCheck.isValid) {
-          logMessage(
-            debug,
-            'hashSensitive',
-            'a field looks like credit card, performing hash.'
-          );
+          logMessage(debug, 'hashSensitive', 'a field looks like credit card, performing hash.');
           returnObject[key] = hash(jsonBody[key]).toString();
         } else {
           returnObject[key] = _hashSensitive(innerVal, debug);
@@ -159,7 +152,7 @@ function _getUrlFromRequestOptions(options, request) {
     var originalOptions = options;
     options = {};
     if (originalOptions) {
-      Object.keys(originalOptions).forEach(function(key) {
+      Object.keys(originalOptions).forEach(function (key) {
         options[key] = originalOptions[key];
       });
     }
@@ -189,8 +182,7 @@ function _getUrlFromRequestOptions(options, request) {
   }
 
   // Mix in default values used by http.request and others
-  options.protocol =
-    options.protocol || (request.agent && request.agent.protocol) || undefined;
+  options.protocol = options.protocol || (request.agent && request.agent.protocol) || undefined;
   options.hostname = options.hostname || 'localhost';
 
   return url.format(options);
@@ -243,11 +235,7 @@ function _safeJsonParse(body) {
           transferEncoding: undefined,
         };
       }
-      if (
-        Array.isArray(body) &&
-        body.every &&
-        body.every(isPlainObjectOrPrimitive)
-      ) {
+      if (Array.isArray(body) && body.every && body.every(isPlainObjectOrPrimitive)) {
         return {
           body: body,
           transferEncoding: undefined,
@@ -322,7 +310,9 @@ function _getEventModelFromRequestAndResponse(
 
   // Decompress requestBody if needed
   var reqHeaders = logData.request.headers || {};
-  var decompressedRequestBody = requestBody ? decompressIfNeeded(requestBody, reqHeaders) : requestBody;
+  var decompressedRequestBody = requestBody
+    ? decompressIfNeeded(requestBody, reqHeaders)
+    : requestBody;
 
   if (decompressedRequestBody) {
     var isReqBodyMaybeJson = _startWithJson(decompressedRequestBody);
@@ -345,7 +335,9 @@ function _getEventModelFromRequestAndResponse(
 
   // Decompress responseBody if needed
   var resHeaders = logData.response.headers || {};
-  var decompressedResponseBody = responseBody ? decompressIfNeeded(responseBody, resHeaders) : responseBody;
+  var decompressedResponseBody = responseBody
+    ? decompressIfNeeded(responseBody, resHeaders)
+    : responseBody;
 
   if (decompressedResponseBody) {
     var isResBodyMaybeJson = _startWithJson(decompressedResponseBody);
@@ -370,10 +362,7 @@ function isJsonHeader(msg) {
     if (headers['content-encoding']) {
       return false;
     }
-    if (
-      headers['content-type'] &&
-      headers['content-type'].indexOf('json') >= 0
-    ) {
+    if (headers['content-type'] && headers['content-type'].indexOf('json') >= 0) {
       return true;
     }
   }
@@ -415,9 +404,7 @@ function appendChunk(buf, chunk) {
       }
     } else if (typeof chunk === 'string') {
       try {
-        return buf
-          ? Buffer.concat([buf, Buffer.from(chunk)])
-          : Buffer.from(chunk);
+        return buf ? Buffer.concat([buf, Buffer.from(chunk)]) : Buffer.from(chunk);
       } catch (err) {
         return buf;
       }
@@ -469,14 +456,14 @@ function getReqHeaders(req) {
 }
 
 function generateUUIDv4() {
-  let timeNow = new Date().getTime();  // Current time in milliseconds
-  let timeRandom = timeNow + Math.random();  // Combine time and random number
+  let timeNow = new Date().getTime(); // Current time in milliseconds
+  let timeRandom = timeNow + Math.random(); // Combine time and random number
 
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      let r = (timeRandom + Math.random() * 16) % 16 | 0;  // Mix in timeRandom for extra entropy
-      timeRandom = Math.floor(timeRandom / 16);
-      let v = c === 'x' ? r : (r & 0x3 | 0x8);  // Handle the fixed bits for UUIDv4
-      return v.toString(16);
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    let r = (timeRandom + Math.random() * 16) % 16 | 0; // Mix in timeRandom for extra entropy
+    timeRandom = Math.floor(timeRandom / 16);
+    let v = c === 'x' ? r : (r & 0x3) | 0x8; // Handle the fixed bits for UUIDv4
+    return v.toString(16);
   });
 }
 

--- a/lib/dataUtils.js
+++ b/lib/dataUtils.js
@@ -4,6 +4,65 @@ var url = require('url');
 var hash = require('crypto-js/md5');
 var isCreditCard = require('card-validator');
 var assign = require('lodash/assign');
+var zlib = require('zlib');
+// Helper to check if buffer is binary (not utf8 string)
+function isBinaryBuffer(buf) {
+  if (!Buffer.isBuffer(buf)) return false;
+  // Heuristic: if buffer contains non-printable characters, treat as binary
+  var text = buf.toString('utf8');
+  // If conversion to string produces replacement chars, it's likely binary
+  return text.includes('\uFFFD') || /[\x00-\x08\x0E-\x1F]/.test(text);
+}
+
+// Decompress if needed based on headers and heuristics
+function decompressIfNeeded(body, headers) {
+  if (!body) return body;
+  var buf = Buffer.isBuffer(body) ? body : Buffer.from(body);
+  var encoding = (headers && (headers['content-encoding'] || headers['Content-Encoding'])) || '';
+  var server = headers && (headers['server'] || headers['Server']) || '';
+  var decompressed = null;
+  var isBinary = isBinaryBuffer(buf);
+  try {
+    if (encoding && isBinary) {
+      if (encoding.includes('gzip')) {
+        decompressed = zlib.gunzipSync(buf);
+      } else if (encoding.includes('deflate')) {
+        decompressed = zlib.inflateSync(buf);
+      } else if (encoding.includes('br')) {
+        decompressed = zlib.brotliDecompressSync(buf);
+      }
+    } else if (isBinary) {
+      // Heuristic: try brotli if server is cloudflare
+      if (server.toLowerCase().includes('cloudflare')) {
+        try {
+          decompressed = zlib.brotliDecompressSync(buf);
+        } catch (e) {
+          // fallback below
+        }
+      }
+      // Try gzip as fallback
+      if (!decompressed) {
+        try {
+          decompressed = zlib.gunzipSync(buf);
+        } catch (e) {}
+      }
+      // Try deflate as fallback
+      if (!decompressed) {
+        try {
+          decompressed = zlib.inflateSync(buf);
+        } catch (e) {}
+      }
+    }
+    if (decompressed) {
+      // Try to return as string if possible
+      return decompressed.toString('utf8');
+    }
+  } catch (err) {
+    // fallback below
+  }
+  // If not decompressed, return original
+  return body;
+}
 
 var logMessage = function (debug, functionName, message, details) {
   if (debug) {
@@ -97,10 +156,10 @@ function _getUrlFromRequestOptions(options, request) {
     options = url.parse(options);
   } else {
     // Avoid modifying the original options object.
-    let originalOptions = options;
+    var originalOptions = options;
     options = {};
     if (originalOptions) {
-      Object.keys(originalOptions).forEach((key) => {
+      Object.keys(originalOptions).forEach(function(key) {
         options[key] = originalOptions[key];
       });
     }
@@ -156,7 +215,7 @@ function isPlainObject(value) {
   if (Object.prototype.toString.call(value) !== '[object Object]') {
     return false;
   }
-  const prototype = Object.getPrototypeOf(value);
+  var prototype = Object.getPrototypeOf(value);
   return prototype === null || prototype === Object.prototype;
 }
 
@@ -164,7 +223,7 @@ function isPlainObjectOrPrimitive(value) {
   if (isPlainObject(value)) {
     return true;
   }
-  const type = typeof value;
+  var type = typeof value;
   return (
     type === 'number' ||
     type === 'boolean' ||
@@ -241,6 +300,7 @@ function getRequestHeaders(requestOptions, request) {
   return {};
 }
 
+// this is mostly for outgoing data capture.
 function _getEventModelFromRequestAndResponse(
   requestOptions,
   request,
@@ -260,17 +320,21 @@ function _getEventModelFromRequestAndResponse(
   logData.request.headers = getRequestHeaders(requestOptions, request);
   logData.request.time = requestTime;
 
-  if (requestBody) {
-    var isReqBodyMaybeJson = _startWithJson(requestBody);
+  // Decompress requestBody if needed
+  var reqHeaders = logData.request.headers || {};
+  var decompressedRequestBody = requestBody ? decompressIfNeeded(requestBody, reqHeaders) : requestBody;
+
+  if (decompressedRequestBody) {
+    var isReqBodyMaybeJson = _startWithJson(decompressedRequestBody);
 
     if (isReqBodyMaybeJson) {
-      var parsedReqBody = _safeJsonParse(requestBody);
+      var parsedReqBody = _safeJsonParse(decompressedRequestBody);
 
       logData.request.transferEncoding = parsedReqBody.transferEncoding;
       logData.request.body = parsedReqBody.body;
     } else {
       logData.request.transferEncoding = 'base64';
-      logData.request.body = _bodyToBase64(requestBody);
+      logData.request.body = _bodyToBase64(decompressedRequestBody);
     }
   }
 
@@ -279,17 +343,21 @@ function _getEventModelFromRequestAndResponse(
   logData.response.status = (response && (response.statusCode || response.status)) || 599;
   logData.response.headers = assign({}, (response && response.headers) || {});
 
-  if (responseBody) {
-    var isResBodyMaybeJson = _startWithJson(responseBody);
+  // Decompress responseBody if needed
+  var resHeaders = logData.response.headers || {};
+  var decompressedResponseBody = responseBody ? decompressIfNeeded(responseBody, resHeaders) : responseBody;
+
+  if (decompressedResponseBody) {
+    var isResBodyMaybeJson = _startWithJson(decompressedResponseBody);
 
     if (isResBodyMaybeJson) {
-      var parsedResBody = _safeJsonParse(responseBody);
+      var parsedResBody = _safeJsonParse(decompressedResponseBody);
 
       logData.response.transferEncoding = parsedResBody.transferEncoding;
       logData.response.body = parsedResBody.body;
     } else {
       logData.response.transferEncoding = 'base64';
-      logData.response.body = _bodyToBase64(responseBody);
+      logData.response.body = _bodyToBase64(decompressedResponseBody);
     }
   }
 
@@ -314,7 +382,7 @@ function isJsonHeader(msg) {
 
 function approximateObjectSize(obj) {
   try {
-    const str = JSON.stringify(obj);
+    var str = JSON.stringify(obj);
     return str.length;
   } catch (err) {
     return 0;

--- a/lib/dataUtils.js
+++ b/lib/dataUtils.js
@@ -496,4 +496,5 @@ module.exports = {
   ensureToString: ensureToString,
   getReqHeaders: getReqHeaders,
   generateUUIDv4: generateUUIDv4,
+  decompressIfNeeded: decompressIfNeeded,
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,7 +111,7 @@ function makeMoesifMiddleware(options) {
    * @type {string}
    */
   config.ApplicationId = options.applicationId || options.ApplicationId;
-  config.UserAgent = 'moesif-nodejs/' + '3.9.1';
+  config.UserAgent = 'moesif-nodejs/' + '3.10.0';
   config.BaseUri = options.baseUri || options.BaseUri || config.BaseUri;
   // default retry to 1.
   config.retry = isNil(options.retry) ? 1 : options.retry;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moesif-nodejs",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moesif-nodejs",
-      "version": "3.9.1",
+      "version": "3.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "bytes": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moesif-nodejs",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "description": "Monitoring agent to log API calls to Moesif for deep API analytics",
   "main": "lib/index.js",
   "typings": "dist/index.d.ts",

--- a/test/decompressUnit.js
+++ b/test/decompressUnit.js
@@ -3,25 +3,34 @@ const zlib = require('zlib');
 const dataUtils = require('../lib/dataUtils');
 
 describe('decompressIfNeeded', function () {
-  it('should decompress brotli-compressed buffer from Cloudflare', function () {
+  it('should decompress brotli-compressed buffer from Cloudflare with text content-type', function() {
     var original = JSON.stringify({ foo: 'bar', baz: 42 });
     var compressed = zlib.brotliCompressSync(Buffer.from(original));
-    var headers = { server: 'cloudflare' };
+    var headers = { server: 'cloudflare', 'content-type': 'application/json' };
     var result = dataUtils.decompressIfNeeded(compressed, headers);
     assert.strictEqual(result, original);
   });
 
-  it('should decompress gzip-compressed buffer', function () {
+  it('should decompress gzip-compressed buffer with text content-type', function() {
     var original = JSON.stringify({ hello: 'world' });
     var compressed = zlib.gzipSync(Buffer.from(original));
-    var headers = { 'content-encoding': 'gzip' };
+    var headers = { 'content-encoding': 'gzip', 'content-type': 'application/json' };
     var result = dataUtils.decompressIfNeeded(compressed, headers);
     assert.strictEqual(result, original);
   });
 
-  it('should return original string if not compressed', function () {
+  it('should skip decompression for non-text content-type (image/png)', function() {
+    var original = Buffer.from([0x89, 0x50, 0x4E, 0x47]); // PNG header
+    var compressed = zlib.gzipSync(original);
+    var headers = { 'content-encoding': 'gzip', 'content-type': 'image/png' };
+    var result = dataUtils.decompressIfNeeded(compressed, headers);
+    // Should return the original compressed buffer, not decompressed
+    assert.deepStrictEqual(result, compressed);
+  });
+
+  it('should return original string if not compressed and text content-type', function() {
     var original = 'plain text';
-    var headers = {};
+    var headers = { 'content-type': 'text/plain' };
     var result = dataUtils.decompressIfNeeded(original, headers);
     assert.strictEqual(result, original);
   });

--- a/test/decompressUnit.js
+++ b/test/decompressUnit.js
@@ -2,8 +2,8 @@ const assert = require('assert');
 const zlib = require('zlib');
 const dataUtils = require('../lib/dataUtils');
 
-describe('decompressIfNeeded', function() {
-  it('should decompress brotli-compressed buffer from Cloudflare', function() {
+describe('decompressIfNeeded', function () {
+  it('should decompress brotli-compressed buffer from Cloudflare', function () {
     var original = JSON.stringify({ foo: 'bar', baz: 42 });
     var compressed = zlib.brotliCompressSync(Buffer.from(original));
     var headers = { server: 'cloudflare' };
@@ -11,7 +11,7 @@ describe('decompressIfNeeded', function() {
     assert.strictEqual(result, original);
   });
 
-  it('should decompress gzip-compressed buffer', function() {
+  it('should decompress gzip-compressed buffer', function () {
     var original = JSON.stringify({ hello: 'world' });
     var compressed = zlib.gzipSync(Buffer.from(original));
     var headers = { 'content-encoding': 'gzip' };
@@ -19,7 +19,7 @@ describe('decompressIfNeeded', function() {
     assert.strictEqual(result, original);
   });
 
-  it('should return original string if not compressed', function() {
+  it('should return original string if not compressed', function () {
     var original = 'plain text';
     var headers = {};
     var result = dataUtils.decompressIfNeeded(original, headers);
@@ -27,18 +27,18 @@ describe('decompressIfNeeded', function() {
   });
 });
 
-describe('getEventModelFromRequestAndResponse', function() {
-  it('should decompress and parse brotli-compressed response body from Cloudflare', function() {
+describe('getEventModelFromRequestAndResponse', function () {
+  it('should decompress and parse brotli-compressed response body from Cloudflare', function () {
     // Simulate a JSON response
-    var jsonResponse = JSON.stringify({ success: true, data: [1,2,3] });
+    var jsonResponse = JSON.stringify({ success: true, data: [1, 2, 3] });
     var compressed = zlib.brotliCompressSync(Buffer.from(jsonResponse));
     var responseHeaders = {
-      'Server': 'cloudflare',
-      'Content-Type': 'application/json'
+      Server: 'cloudflare',
+      'Content-Type': 'application/json',
     };
     var response = {
       statusCode: 200,
-      headers: responseHeaders
+      headers: responseHeaders,
     };
     var result = dataUtils.getEventModelFromRequestAndResponse(
       'https://api.example.com/test',
@@ -49,16 +49,64 @@ describe('getEventModelFromRequestAndResponse', function() {
       Date.now(),
       compressed
     );
-    assert.deepStrictEqual(result.response.body, { success: true, data: [1,2,3] });
+    assert.deepStrictEqual(result.response.body, { success: true, data: [1, 2, 3] });
     assert.strictEqual(result.response.transferEncoding, undefined);
   });
 
-  it('should fallback to base64 if not decompressible', function() {
-    var binary = Buffer.from([0x01, 0x02, 0x03, 0x04]);
-    var responseHeaders = { 'Server': 'cloudflare' };
+
+  it('should handle a Cloudflare API response with base64 _raw body', function () {
+    var requestHeaders = {
+      'X-Request-Source': 'standard',
+      'Content-Type': 'application/json',
+      'Content-Length': 2,
+      'Accept-Encoding': 'gzip, compress, deflate, br',
+      Accept: 'application/json, text/plain, */*',
+    };
+    var responseHeaders = {
+      Connection: 'keep-alive',
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cf-Cache-Status': 'DYNAMIC',
+      'Transfer-Encoding': 'chunked',
+      Server: 'cloudflare',
+    };
     var response = {
       statusCode: 200,
-      headers: responseHeaders
+      headers: responseHeaders,
+    };
+    var base64Raw ='CwSAAAAAADA=';
+    var decodedRaw = Buffer.from(base64Raw, 'base64');
+    var result = dataUtils.getEventModelFromRequestAndResponse(
+      {
+        method: 'GET',
+        headers: requestHeaders,
+        path: '/api/v1/test',
+      },
+      {},
+      Date.now(),
+      null,
+      response,
+      Date.now(),
+      decodedRaw
+    );
+    // If decompressible, should be JSON, else base64
+    if (typeof result.response.body === 'object') {
+      // Should be a valid object (if decompressible)
+      assert.ok(result.response.body);
+      console.log('Decompressed body:', result.response.body);
+    } else {
+      // Should fallback to base64 string
+      console.log('Base64 body:', result.response.body);
+      assert.strictEqual(result.response.body, base64Raw);
+      assert.strictEqual(result.response.transferEncoding, 'base64');
+    }
+  });
+
+  it('should fallback to base64 if not decompressible', function () {
+    var binary = Buffer.from([0x01, 0x02, 0x03, 0x04]);
+    var responseHeaders = { Server: 'cloudflare' };
+    var response = {
+      statusCode: 200,
+      headers: responseHeaders,
     };
     var result = dataUtils.getEventModelFromRequestAndResponse(
       'https://api.example.com/test',

--- a/test/decompressUnit.js
+++ b/test/decompressUnit.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+const zlib = require('zlib');
+const dataUtils = require('../lib/dataUtils');
+
+describe('decompressIfNeeded', function() {
+  it('should decompress brotli-compressed buffer from Cloudflare', function() {
+    var original = JSON.stringify({ foo: 'bar', baz: 42 });
+    var compressed = zlib.brotliCompressSync(Buffer.from(original));
+    var headers = { server: 'cloudflare' };
+    var result = dataUtils.decompressIfNeeded(compressed, headers);
+    assert.strictEqual(result, original);
+  });
+
+  it('should decompress gzip-compressed buffer', function() {
+    var original = JSON.stringify({ hello: 'world' });
+    var compressed = zlib.gzipSync(Buffer.from(original));
+    var headers = { 'content-encoding': 'gzip' };
+    var result = dataUtils.decompressIfNeeded(compressed, headers);
+    assert.strictEqual(result, original);
+  });
+
+  it('should return original string if not compressed', function() {
+    var original = 'plain text';
+    var headers = {};
+    var result = dataUtils.decompressIfNeeded(original, headers);
+    assert.strictEqual(result, original);
+  });
+});
+
+describe('getEventModelFromRequestAndResponse', function() {
+  it('should decompress and parse brotli-compressed response body from Cloudflare', function() {
+    // Simulate a JSON response
+    var jsonResponse = JSON.stringify({ success: true, data: [1,2,3] });
+    var compressed = zlib.brotliCompressSync(Buffer.from(jsonResponse));
+    var responseHeaders = {
+      'Server': 'cloudflare',
+      'Content-Type': 'application/json'
+    };
+    var response = {
+      statusCode: 200,
+      headers: responseHeaders
+    };
+    var result = dataUtils.getEventModelFromRequestAndResponse(
+      'https://api.example.com/test',
+      {},
+      Date.now(),
+      null,
+      response,
+      Date.now(),
+      compressed
+    );
+    assert.deepStrictEqual(result.response.body, { success: true, data: [1,2,3] });
+    assert.strictEqual(result.response.transferEncoding, undefined);
+  });
+
+  it('should fallback to base64 if not decompressible', function() {
+    var binary = Buffer.from([0x01, 0x02, 0x03, 0x04]);
+    var responseHeaders = { 'Server': 'cloudflare' };
+    var response = {
+      statusCode: 200,
+      headers: responseHeaders
+    };
+    var result = dataUtils.getEventModelFromRequestAndResponse(
+      'https://api.example.com/test',
+      {},
+      Date.now(),
+      null,
+      response,
+      Date.now(),
+      binary
+    );
+    assert.strictEqual(result.response.transferEncoding, 'base64');
+    assert.strictEqual(result.response.body, binary.toString('base64'));
+  });
+});


### PR DESCRIPTION
- For outgoing API calls, seems there could be some third party vendors that do not add "Content-Encoding" when compressed. 
- if data is binary and content-type is JSON, XML or txt, we'll try to decode it even if content-encoding does not exist.  